### PR TITLE
Add SBOM generation via kusari platform generate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Using kusari-cli for upload functionality
-FROM ghcr.io/kusaridev/kusari-cli@sha256:4a3af56d8eadfd1444f7f8295d978902c8f13b5382dbe2a978e41d8b4069fe40 AS kusari
+FROM ghcr.io/kusaridev/kusari-cli@sha256:2323d84cb0d01db00c159335d2fad437fe0ee793382667353c9019268d84038e AS kusari
 
 # Use Chainguard wolfi-base as final base to provide shell environment
-FROM cgr.dev/chainguard/wolfi-base@sha256:31da6565f35af6401031c1d7aa91dc84ac76c5c48edd17fb90f0ed9e3173c7a9
+FROM cgr.dev/chainguard/wolfi-base@sha256:5743937d521cbeb9e8c73bf1bd7ba2589c178940eb03d7b148efecc962be8587
 
 # Copy kusari binary from the kusari-cli image
 COPY --from=kusari /ko-app/kusari /usr/local/bin/kusari

--- a/README.md
+++ b/README.md
@@ -54,6 +54,21 @@ Or scan a container image instead of a source tree:
       client-secret: ${{ secrets.KUSARI_CLIENT_SECRET }}
 ```
 
+mikebom auto-derives the SBOM's subject name/version when it finds a recognizable manifest (Cargo.toml, package.json, pom.xml, etc.), but falls back to generic names like `filesystem-scan` when scanning a container image or a directory without one. Set `root-name` / `root-version` to override the fallback:
+
+```yaml
+  - uses: kusaridev/kusari-ingest@v0
+    name: Kusari Ingestion (image, with root identity)
+    with:
+      generate: true
+      image: 'ghcr.io/myorg/myapp:${{ github.sha }}'
+      root-name: ${{ github.event.repository.name }}
+      root-version: ${{ github.ref_name }}@${{ github.sha }}
+      tenant-endpoint: 'https://[kusari-tenant-id].api.us.kusari.cloud'
+      client-id: ${{ secrets.KUSARI_CLIENT_ID }}
+      client-secret: ${{ secrets.KUSARI_CLIENT_SECRET }}
+```
+
 ## Inputs
 
 ### `file-path`
@@ -78,7 +93,15 @@ Or scan a container image instead of a source tree:
 
 ### `mikebom-args`
 
-**Optional** - Extra arguments appended verbatim to `mikebom sbom scan` after `--`. Do not override `--output` here; use `output-path` instead.
+**Optional** - Extra arguments appended verbatim to `mikebom sbom scan` after `--`. Do not pass `--output`, `--root-name`, or `--root-version` here; use the `output-path`, `root-name`, and `root-version` inputs instead — the action will error on the conflict.
+
+### `root-name`
+
+**Optional** - Passed to mikebom as `--root-name` when set. When left empty, mikebom uses its own auto-derivation. Default: `""`.
+
+### `root-version`
+
+**Optional** - Passed to mikebom as `--root-version` when set. When left empty, mikebom uses its own auto-derivation. Default: `""`.
 
 ### `tenant-endpoint`
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,59 @@ steps:
       client-secret: ${{ secrets.KUSARI_CLIENT_SECRET }}
 ```
 
+### Generating an SBOM from source
+
+Set `generate: true` to have the action build a CycloneDX SBOM with `kusari platform generate` (mikebom) and upload it. No prebuilt SBOM file is required.
+
+```yaml
+  - uses: kusaridev/kusari-ingest@v0
+    name: Kusari Ingestion (generate)
+    with:
+      generate: true
+      source-path: '.'
+      tenant-endpoint: 'https://[kusari-tenant-id].api.us.kusari.cloud'
+      client-id: ${{ secrets.KUSARI_CLIENT_ID }}
+      client-secret: ${{ secrets.KUSARI_CLIENT_SECRET }}
+```
+
+Or scan a container image instead of a source tree:
+
+```yaml
+  - uses: kusaridev/kusari-ingest@v0
+    name: Kusari Ingestion (image)
+    with:
+      generate: true
+      image: 'ghcr.io/myorg/myapp:${{ github.sha }}'
+      tenant-endpoint: 'https://[kusari-tenant-id].api.us.kusari.cloud'
+      client-id: ${{ secrets.KUSARI_CLIENT_ID }}
+      client-secret: ${{ secrets.KUSARI_CLIENT_SECRET }}
+```
+
 ## Inputs
 
 ### `file-path`
 
-**Required** - Path to directory or specific file to ingest
+**Required** when `generate` is `false` (default). Ignored when `generate` is `true`. Path to directory or specific file to ingest.
+
+### `generate`
+
+**Optional** - When `true`, the action first runs `kusari platform generate` (via mikebom) on `source-path` to produce an SBOM, then uploads that SBOM. Default: `false`.
+
+### `source-path`
+
+**Optional** - Source path scanned by mikebom when `generate` is `true`. Passed as `--path`. Mutually exclusive with `image`. Default: `.`.
+
+### `image`
+
+**Optional** - Container image to scan when `generate` is `true`. Accepts an OCI reference (e.g. `ghcr.io/foo/bar:tag`) or the path to a `docker save` tarball. Passed to mikebom as `--image`. When set, overrides `source-path`. Default: `""`.
+
+### `output-path`
+
+**Optional** - Where the generated SBOM is written and what is uploaded afterwards. Passed to mikebom as `--output`. Default: `project.cdx.json`. Set this (and a matching format flag in `mikebom-args`) to produce SPDX, e.g. `project.spdx.json`.
+
+### `mikebom-args`
+
+**Optional** - Extra arguments appended verbatim to `mikebom sbom scan` after `--`. Do not override `--output` here; use `output-path` instead.
 
 ### `tenant-endpoint`
 

--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ Or scan a container image instead of a source tree:
 
 ### `source-path`
 
-**Optional** - Source path scanned by mikebom when `generate` is `true`. Passed as `--path`. Mutually exclusive with `image`. Default: `.`.
+**Optional** - Source path scanned by mikebom when `generate` is `true`. Passed as `--path`. Exactly one of `source-path` or `image` is required when `generate` is `true`. Default: `""`.
 
 ### `image`
 
-**Optional** - Container image to scan when `generate` is `true`. Accepts an OCI reference (e.g. `ghcr.io/foo/bar:tag`) or the path to a `docker save` tarball. Passed to mikebom as `--image`. When set, overrides `source-path`. Default: `""`.
+**Optional** - Container image to scan when `generate` is `true`. Accepts an OCI reference (e.g. `ghcr.io/foo/bar:tag`) or the path to a `docker save` tarball. Passed to mikebom as `--image`. Exactly one of `source-path` or `image` is required when `generate` is `true`. Default: `""`.
 
 ### `output-path`
 
@@ -149,7 +149,7 @@ The action automatically captures repository metadata to enable traceability for
 | `forge` | GitHub server URL | `github.com` or `github.enterprise.com` |
 | `org` | Repository owner | `kusaridev` |
 | `repo` | Repository name | `kusari-ingest` |
-| `subrepo_path` | Derived from `file-path` | `app/frontend` (from `app/frontend/sbom.json`) |
+| `subrepo_path` | Derived from `file-path` in upload mode, from `source-path` in generate mode, and omitted in image mode | `app/frontend` (from `app/frontend/sbom.json`, or from `source-path: app/frontend`) |
 
 This metadata is automatically attached to uploaded SBOMs without any additional configuration.
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ mikebom auto-derives the SBOM's subject name/version when it finds a recognizabl
 
 ### `file-path`
 
-**Required** when `generate` is `false` (default). Ignored when `generate` is `true`. Path to directory or specific file to ingest.
+**Required** when `generate` is `false` (default). Must be empty when `generate` is `true` — the action uploads the generated SBOM, not a pre-existing file. Path to directory or specific file to ingest.
 
 ### `generate`
 
@@ -97,11 +97,11 @@ mikebom auto-derives the SBOM's subject name/version when it finds a recognizabl
 
 ### `root-name`
 
-**Optional** - Passed to mikebom as `--root-name` when set. When left empty, mikebom uses its own auto-derivation. Default: `""`.
+**Optional** - Passed to mikebom as `--root-name` when set, so the generated SBOM's `metadata.component.name` reflects the value (rather than mikebom's generic fallback like `filesystem-scan`). When left empty, mikebom uses its own auto-derivation. To override only the value Kusari Platform reads at ingestion (without changing the SBOM file's contents), use `sbom-subject-name-override` instead. Default: `""`.
 
 ### `root-version`
 
-**Optional** - Passed to mikebom as `--root-version` when set. When left empty, mikebom uses its own auto-derivation. Default: `""`.
+**Optional** - Passed to mikebom as `--root-version` when set, so the generated SBOM's `metadata.component.version` reflects the value. When left empty, mikebom uses its own auto-derivation. To override only the value Kusari Platform reads at ingestion, use `sbom-subject-version-override` instead. Default: `""`.
 
 ### `tenant-endpoint`
 
@@ -149,11 +149,11 @@ mikebom auto-derives the SBOM's subject name/version when it finds a recognizabl
 
 ### `sbom-subject-name-override`
 
-**Optional** - SBOM Subject Name override (for SBOMs only). This allows you to override the subject name extracted from the SBOM document. Default: `""`
+**Optional** - SBOM Subject Name override (for SBOMs only). Overrides the subject name the Kusari Platform reads from the uploaded SBOM document at ingestion time; the SBOM file's own `metadata.component.name` is unchanged. To change what mikebom writes *inside* the generated SBOM, use `root-name` instead (generate mode only). Default: `""`
 
 ### `sbom-subject-version-override`
 
-**Optional** - SBOM Subject Version override (for SBOMs only). This allows you to override the subject version extracted from the SBOM document. Default: `""`
+**Optional** - SBOM Subject Version override (for SBOMs only). Overrides the subject version the Kusari Platform reads from the uploaded SBOM document at ingestion time; the SBOM file's own version field is unchanged. To change what mikebom writes *inside* the generated SBOM, use `root-version` instead (generate mode only). Default: `""`
 
 ### `commit-sha`
 

--- a/action.yaml
+++ b/action.yaml
@@ -7,8 +7,29 @@ branding:
 author: 'Kusari'
 inputs:
   file-path:
-    description: 'Path to directory or specific file to ingest'
-    required: true
+    description: 'Path to directory or specific file to ingest. Required unless generate is true.'
+    required: false
+    default: ""
+  generate:
+    description: 'Generate an SBOM with `kusari platform generate` (via mikebom) and upload it, instead of uploading an existing file.'
+    required: false
+    default: "false"
+  source-path:
+    description: 'Source path to scan when generate is true. Passed to mikebom as `--path`. Mutually exclusive with `image`. Defaults to the workspace root.'
+    required: false
+    default: "."
+  image:
+    description: 'Container image reference (OCI ref or `docker save` tarball path) to scan when generate is true. Passed to mikebom as `--image`. When set, overrides `source-path`.'
+    required: false
+    default: ""
+  output-path:
+    description: 'Path where the generated SBOM is written (used when generate is true). Passed to mikebom as `--output` and then used as the file to upload. Default matches mikebom''s CycloneDX default.'
+    required: false
+    default: "project.cdx.json"
+  mikebom-args:
+    description: 'Additional flags passed verbatim to `mikebom sbom scan` after `--` when generate is true. Avoid overriding `--output` here; use the `output-path` input instead.'
+    required: false
+    default: ""
   tenant-endpoint:
     description: 'Kusari Platform tenant api endpoint'
     required: true
@@ -86,3 +107,8 @@ runs:
     - "--sbom-subject-version-override=${{ inputs.sbom-subject-version-override }}"
     - "--commit-sha=${{ inputs.commit-sha }}"
     - "--wait=${{ inputs.wait }}"
+    - "--generate=${{ inputs.generate }}"
+    - "--source-path=${{ inputs.source-path }}"
+    - "--image=${{ inputs.image }}"
+    - "--output-path=${{ inputs.output-path }}"
+    - "--mikebom-args=${{ inputs.mikebom-args }}"

--- a/action.yaml
+++ b/action.yaml
@@ -15,11 +15,11 @@ inputs:
     required: false
     default: "false"
   source-path:
-    description: 'Source path to scan when generate is true. Passed to mikebom as `--path`. Mutually exclusive with `image`. Defaults to the workspace root.'
+    description: 'Source path to scan when generate is true. Passed to mikebom as `--path`. Exactly one of `source-path` or `image` is required when generate is true.'
     required: false
-    default: "."
+    default: ""
   image:
-    description: 'Container image reference (OCI ref or `docker save` tarball path) to scan when generate is true. Passed to mikebom as `--image`. When set, overrides `source-path`.'
+    description: 'Container image reference (OCI ref or `docker save` tarball path) to scan when generate is true. Passed to mikebom as `--image`. Exactly one of `source-path` or `image` is required when generate is true.'
     required: false
     default: ""
   output-path:

--- a/action.yaml
+++ b/action.yaml
@@ -30,6 +30,14 @@ inputs:
     description: 'Additional flags passed verbatim to `mikebom sbom scan` after `--` when generate is true. Avoid overriding `--output` here; use the `output-path` input instead.'
     required: false
     default: ""
+  root-name:
+    description: 'mikebom `--root-name` value used when generate is true. When unset, mikebom uses its own auto-derivation.'
+    required: false
+    default: ""
+  root-version:
+    description: 'mikebom `--root-version` value used when generate is true. When unset, mikebom uses its own auto-derivation.'
+    required: false
+    default: ""
   tenant-endpoint:
     description: 'Kusari Platform tenant api endpoint'
     required: true
@@ -112,3 +120,5 @@ runs:
     - "--image=${{ inputs.image }}"
     - "--output-path=${{ inputs.output-path }}"
     - "--mikebom-args=${{ inputs.mikebom-args }}"
+    - "--root-name=${{ inputs.root-name }}"
+    - "--root-version=${{ inputs.root-version }}"

--- a/action.yaml
+++ b/action.yaml
@@ -7,7 +7,7 @@ branding:
 author: 'Kusari'
 inputs:
   file-path:
-    description: 'Path to directory or specific file to ingest. Required unless generate is true.'
+    description: 'Path to directory or specific file to ingest. Required when generate is false; must be empty when generate is true (the action uploads the generated SBOM).'
     required: false
     default: ""
   generate:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 set -e
+# Disable pathname (glob) expansion. The script word-splits a few
+# user-supplied strings (notably ${MIKEBOM_ARGS}) by intentionally
+# leaving them unquoted; without -f those expansions would also be
+# globbed against the workspace, which would silently mutate the
+# user's flags based on what files happen to exist in cwd.
+set -f
 
 # Parse arguments
 FILE_PATH=""
@@ -109,8 +115,14 @@ fi
 
 # In generate mode, exactly one scan target must be supplied. Setting both
 # would silently let one win; setting neither would hand an empty --path to
-# mikebom. Reject both cases up front.
+# mikebom. Reject both cases up front. Also reject a stray file-path — the
+# action uploads the generated SBOM, so any file-path the caller set would
+# be silently dropped.
 if [ "${GENERATE}" = "true" ]; then
+  if [ -n "${FILE_PATH}" ]; then
+    echo "file-path must not be set when generate is true; the action uploads the generated SBOM"
+    exit 1
+  fi
   if [ -z "${IMAGE}" ] && [ -z "${SOURCE_PATH}" ]; then
     echo "one of image or source-path must be set when generate is true"
     exit 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,7 @@ SBOM_SUBJECT_VERSION_OVERRIDE=""
 WAIT="true"
 COMMIT_SHA=""
 GENERATE="false"
-SOURCE_PATH="."
+SOURCE_PATH=""
 IMAGE=""
 OUTPUT_PATH="project.cdx.json"
 MIKEBOM_ARGS=""
@@ -98,6 +98,36 @@ if [ "${GENERATE}" != "true" ] && [ -z "${FILE_PATH}" ]; then
   echo "file-path is required when generate is not enabled"
   exit 1
 fi
+
+# In generate mode, exactly one scan target must be supplied. Setting both
+# would silently let one win; setting neither would hand an empty --path to
+# mikebom. Reject both cases up front.
+if [ "${GENERATE}" = "true" ]; then
+  if [ -z "${IMAGE}" ] && [ -z "${SOURCE_PATH}" ]; then
+    echo "one of image or source-path must be set when generate is true"
+    exit 1
+  fi
+  if [ -n "${IMAGE}" ] && [ -n "${SOURCE_PATH}" ]; then
+    echo "image and source-path are mutually exclusive; set only one when generate is true"
+    exit 1
+  fi
+fi
+
+# Users sometimes try to set mikebom's --output via mikebom-args; that
+# silently desyncs from the file the upload step expects. Refuse the
+# override and point them at the output-path input. Iterate the same way
+# the actual invocation does (unquoted word-splitting) so we catch the
+# flag regardless of which whitespace (spaces, tabs, newlines from a
+# multiline YAML scalar) separates the tokens.
+# shellcheck disable=SC2086
+for token in ${MIKEBOM_ARGS}; do
+  case "$token" in
+    --output|--output=*)
+      echo "mikebom-args must not contain --output; use the output-path input instead"
+      exit 1
+      ;;
+  esac
+done
 
 # Fail if CLIENT_ID or CLIENT_SECRET is still empty
 if [ -z "${CLIENT_ID}" ] || [ -z ${CLIENT_SECRET} ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,6 +18,11 @@ SBOM_SUBJECT_NAME_OVERRIDE=""
 SBOM_SUBJECT_VERSION_OVERRIDE=""
 WAIT="true"
 COMMIT_SHA=""
+GENERATE="false"
+SOURCE_PATH="."
+IMAGE=""
+OUTPUT_PATH="project.cdx.json"
+MIKEBOM_ARGS=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -69,9 +74,30 @@ while [ $# -gt 0 ]; do
     --commit-sha=*)
       COMMIT_SHA="${1#*=}"
       ;;
+    --generate=*)
+      GENERATE="${1#*=}"
+      ;;
+    --source-path=*)
+      SOURCE_PATH="${1#*=}"
+      ;;
+    --image=*)
+      IMAGE="${1#*=}"
+      ;;
+    --output-path=*)
+      OUTPUT_PATH="${1#*=}"
+      ;;
+    --mikebom-args=*)
+      MIKEBOM_ARGS="${1#*=}"
+      ;;
   esac
   shift
 done
+
+# In upload mode, file-path is required. In generate mode it is unused.
+if [ "${GENERATE}" != "true" ] && [ -z "${FILE_PATH}" ]; then
+  echo "file-path is required when generate is not enabled"
+  exit 1
+fi
 
 # Fail if CLIENT_ID or CLIENT_SECRET is still empty
 if [ -z "${CLIENT_ID}" ] || [ -z ${CLIENT_SECRET} ]; then
@@ -99,9 +125,15 @@ if [ -n "${GITHUB_REPOSITORY}" ]; then
   REPO="${GITHUB_REPOSITORY#*/}"
 fi
 
-# Auto-derive subrepo path from file-path
+# Auto-derive subrepo path. In generate mode it tracks source-path (unless
+# we're scanning an image, in which case there is no meaningful subrepo);
+# otherwise it tracks file-path.
 SUBREPO_PATH=""
-if [ -n "${FILE_PATH}" ]; then
+if [ "${GENERATE}" = "true" ]; then
+  if [ -z "${IMAGE}" ]; then
+    SUBREPO_PATH="${SOURCE_PATH}"
+  fi
+elif [ -n "${FILE_PATH}" ]; then
   if [ -d "${FILE_PATH}" ]; then
     # FILE_PATH is a directory, use it as subrepo path
     SUBREPO_PATH="${FILE_PATH}"
@@ -109,6 +141,9 @@ if [ -n "${FILE_PATH}" ]; then
     # FILE_PATH is a file, extract the directory portion
     SUBREPO_PATH=$(dirname "${FILE_PATH}")
   fi
+fi
+
+if [ -n "${SUBREPO_PATH}" ]; then
   # Normalize: remove leading ./ and trailing /
   SUBREPO_PATH=$(echo "${SUBREPO_PATH}" | sed -E 's|^\./||' | sed -E 's|/$||')
   # If empty or just ".", set to "."
@@ -137,6 +172,27 @@ kusari auth login \
   --client-id="${CLIENT_ID}" \
   --client-secret="${CLIENT_SECRET}" \
   --auth-endpoint="${AUTH_ENDPOINT}"
+
+# In generate mode, produce the SBOM with mikebom first, then upload the
+# resulting file via the normal upload codepath below. mikebom requires
+# exactly one of --image or --path as the scan target.
+if [ "${GENERATE}" = "true" ]; then
+  if [ -n "${IMAGE}" ]; then
+    echo "Generating SBOM for image ${IMAGE} with kusari platform generate..."
+    SCAN_TARGET_FLAG="--image"
+    SCAN_TARGET_VALUE="${IMAGE}"
+  else
+    echo "Generating SBOM for source path ${SOURCE_PATH} with kusari platform generate..."
+    SCAN_TARGET_FLAG="--path"
+    SCAN_TARGET_VALUE="${SOURCE_PATH}"
+  fi
+  # shellcheck disable=SC2086
+  kusari platform generate -- \
+    --output "${OUTPUT_PATH}" \
+    "${SCAN_TARGET_FLAG}" "${SCAN_TARGET_VALUE}" \
+    ${MIKEBOM_ARGS}
+  FILE_PATH="${OUTPUT_PATH}"
+fi
 
 # Execute upload command
 echo "Uploading to Kusari Platform..."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,6 +23,8 @@ SOURCE_PATH=""
 IMAGE=""
 OUTPUT_PATH="project.cdx.json"
 MIKEBOM_ARGS=""
+ROOT_NAME=""
+ROOT_VERSION=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -89,6 +91,12 @@ while [ $# -gt 0 ]; do
     --mikebom-args=*)
       MIKEBOM_ARGS="${1#*=}"
       ;;
+    --root-name=*)
+      ROOT_NAME="${1#*=}"
+      ;;
+    --root-version=*)
+      ROOT_VERSION="${1#*=}"
+      ;;
   esac
   shift
 done
@@ -124,6 +132,14 @@ for token in ${MIKEBOM_ARGS}; do
   case "$token" in
     --output|--output=*)
       echo "mikebom-args must not contain --output; use the output-path input instead"
+      exit 1
+      ;;
+    --root-name|--root-name=*)
+      echo "mikebom-args must not contain --root-name; use the root-name input instead"
+      exit 1
+      ;;
+    --root-version|--root-version=*)
+      echo "mikebom-args must not contain --root-version; use the root-version input instead"
       exit 1
       ;;
   esac
@@ -216,11 +232,17 @@ if [ "${GENERATE}" = "true" ]; then
     SCAN_TARGET_FLAG="--path"
     SCAN_TARGET_VALUE="${SOURCE_PATH}"
   fi
-  # shellcheck disable=SC2086
-  kusari platform generate -- \
+  set -- kusari platform generate -- \
     --output "${OUTPUT_PATH}" \
-    "${SCAN_TARGET_FLAG}" "${SCAN_TARGET_VALUE}" \
-    ${MIKEBOM_ARGS}
+    "${SCAN_TARGET_FLAG}" "${SCAN_TARGET_VALUE}"
+  if [ -n "${ROOT_NAME}" ]; then
+    set -- "$@" --root-name "${ROOT_NAME}"
+  fi
+  if [ -n "${ROOT_VERSION}" ]; then
+    set -- "$@" --root-version "${ROOT_VERSION}"
+  fi
+  # shellcheck disable=SC2086
+  "$@" ${MIKEBOM_ARGS}
   FILE_PATH="${OUTPUT_PATH}"
 fi
 


### PR DESCRIPTION
## Summary
- Add a `generate: true` mode that produces a CycloneDX SBOM with `kusari platform generate` (mikebom) and uploads it via the existing upload codepath.
- Supports scanning either a source tree (`source-path`) or a container image (`image`); exactly one is required when generate is true.
- New inputs: `generate`, `source-path`, `image`, `output-path`, `mikebom-args`, `root-name`, `root-version`.
- `file-path` is now optional (required when not generating; must be empty when generating).
- Bump pinned kusari-cli and wolfi-base image digests.

## Test plan
- [x] Built locally; `kusari platform generate -- --image alpine:3.20` produces a valid CycloneDX 1.6 SBOM.
- [x] Private image pull verified with `MIKEBOM_REGISTRY_GHCR_IO_USERNAME`/`_PASSWORD` env vars against `ghcr.io/kusaridev/kusari-uploader`.
- [x] End-to-end (generate → upload) run against a Kusari sandbox tenant in both source and image modes.
- [ ] Run the action from a workflow on a fork/branch to validate GitHub Actions wiring (env-var forwarding, secrets plumbing, forge/org/repo auto-detect).