### PR TITLE
Update kusari-cli to v2.8.1

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -132,7 +132,7 @@ runs:
     - name: Install kusari CLI
       shell: bash
       env:
-        KUSARI_CLI_VERSION: "2.8.0"   # keep in sync with kusari-cli releases
+        KUSARI_CLI_VERSION: "2.8.1"   # keep in sync with kusari-cli releases
       run: |
         set -euo pipefail
         case "${RUNNER_OS}" in


### PR DESCRIPTION
Bump KUSARI_CLI_VERSION in action.yaml from 2.8.0 to 2.8.1. The download URLs derive from this variable, so no other changes needed.