### PR TITLE
Update kusari-cli to v2.10.1

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -136,7 +136,7 @@ runs:
     - name: Install kusari CLI
       shell: bash
       env:
-        KUSARI_CLI_VERSION: "2.9.2"   # keep in sync with kusari-cli releases
+        KUSARI_CLI_VERSION: "2.10.1"   # keep in sync with kusari-cli releases
       run: |
         set -euo pipefail
         case "${RUNNER_OS}" in


### PR DESCRIPTION
Bumps the pinned kusari-cli release to v2.10.1.